### PR TITLE
Add experiment metadata

### DIFF
--- a/api/pages/api/v1/_helpers/posthog.ts
+++ b/api/pages/api/v1/_helpers/posthog.ts
@@ -7,10 +7,17 @@ export const captureEvent = async (
   clientId: string,
   properties: any
 ) => {
+  // We have to re-expose here to get the variant that is associated with user. Cannot expose on client in web-pixel as that would bloat it beyond 128kb size limit
+  client?.identify({ distinctId: clientId, properties: { store: store } });
+  const variant = await client.getFeatureFlag("enabled", clientId);
+
   client.capture({
     distinctId: clientId,
     event: properties.name,
-    properties: properties,
+    properties: {
+      ...properties,
+      "$feature/enabled": variant, // Odd formatting but this key string gets is necessary for events to show up in posthog's experiment tab
+    },
   });
 
   const { context, id, name, timestamp, detail } = properties;
@@ -18,9 +25,9 @@ export const captureEvent = async (
     {
       id: id,
       timestamp: timestamp,
-      detail: detail, // convert data object to JSON string
+      detail: detail,
       clientId: clientId,
-      context: context, // convert context object to JSON string
+      context: context,
       name: name,
       store: store,
     },


### PR DESCRIPTION
Add metadata to events so that they show up in "A/B testing" tab in posthog. Events were being ingested correctly but required the "$feature/enabled" key in `api/pages/api/v1/_helpers/posthog.ts` to be assigned to a experiment correctly.