### PR TITLE
Only send API calls when command palette is visible

### DIFF
--- a/frontend/components/icon.tsx
+++ b/frontend/components/icon.tsx
@@ -107,6 +107,7 @@ export default function Icon({ props }) {
   const handleIconClick = (event) => {
     event.stopPropagation();
     const overlayDiv = props.overlayDiv;
+    props.mountOverlay();
     toggleOverlayVisibility(overlayDiv);
   };
 

--- a/frontend/entrypoints/createElements.tsx
+++ b/frontend/entrypoints/createElements.tsx
@@ -6,7 +6,7 @@ import ReactDOM from "react-dom/client";
 import "vite/modulepreload-polyfill";
 import "./section.css";
 
-export function createIcon(home, mountDiv, overlayDiv, iconSize) {
+export function createIcon(home, mountDiv, overlayDiv, mountOverlay, iconSize) {
   const element = document.getElementById(mountDiv);
   if (!element) {
     throw new Error(`Element with id "${mountDiv}" not found`);
@@ -19,6 +19,7 @@ export function createIcon(home, mountDiv, overlayDiv, iconSize) {
           mountDiv: mountDiv,
           overlayDiv: overlayDiv,
           iconSize: iconSize,
+          mountOverlay: mountOverlay,
         }}
       />
     </PostHogProvider>
@@ -45,13 +46,18 @@ export function createOverlayDiv() {
     overlayDiv.style.transition =
       "opacity 200ms ease, visibility 0s ease 200ms";
     overlayDiv.className = "overlay";
-    document.body.appendChild(overlayDiv);
-    ReactDOM.createRoot(overlayDiv).render(
-      <PostHogProvider apiKey="phc_6YNAbj13W6OWd4CsBcXtyhy4zWUG3SNRb9EkXYjiGk4">
-        <CommandPalette props={{ overlayDiv: overlayDiv }} />
-      </PostHogProvider>
-    );
+  }
+  // Function to append the overlayDiv when needed
+  function mountOverlay() {
+    if (!document.body.contains(overlayDiv)) {
+      document.body.appendChild(overlayDiv);
+      ReactDOM.createRoot(overlayDiv).render(
+        <PostHogProvider apiKey="phc_6YNAbj13W6OWd4CsBcXtyhy4zWUG3SNRb9EkXYjiGk4">
+          <CommandPalette props={{ overlayDiv: overlayDiv }} />
+        </PostHogProvider>
+      );
+    }
   }
 
-  return overlayDiv;
+  return { overlayDiv, mountOverlay };
 }

--- a/frontend/entrypoints/embed.tsx
+++ b/frontend/entrypoints/embed.tsx
@@ -1,5 +1,5 @@
 import "vite/modulepreload-polyfill";
+import { createIcon, createOverlayDiv } from "./createElements";
 import "./section.css";
-import { createOverlayDiv, createIcon } from "./createElements";
-
-createIcon(embed_home, "embed", createOverlayDiv(), 100);
+const { overlayDiv, mountOverlay } = createOverlayDiv();
+createIcon(embed_home, "embed", overlayDiv, mountOverlay, 100);

--- a/frontend/entrypoints/section.tsx
+++ b/frontend/entrypoints/section.tsx
@@ -1,5 +1,6 @@
 import "vite/modulepreload-polyfill";
+import { createIcon, createOverlayDiv } from "./createElements";
 import "./section.css";
-import { createOverlayDiv, createIcon } from "./createElements";
 
-createIcon(home, "section", createOverlayDiv(), 30);
+const { overlayDiv, mountOverlay } = createOverlayDiv();
+createIcon(home, "section", overlayDiv, mountOverlay, 30);


### PR DESCRIPTION
- We were sending openai calls for the command palette (MessageSource.CHAT_GREETING and MessageSource.HINTS) regardless of whether palette was open.
- Fix this by mounting and rendering only after icon is clicked